### PR TITLE
Update sync progress notifications quietly

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/notifications/GenericSyncNotification.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/notifications/GenericSyncNotification.kt
@@ -49,6 +49,7 @@ class GenericSyncNotification(var mContext: Context) {
                 cancelPendingIntent
             )
             .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOnlyAlertOnce(true)
             .setProgress(100, percent, false)
     }
 


### PR DESCRIPTION
Every progress update on a sync operation currently causes the notification to play sound, vibrate, etc.