### PR TITLE
Rework rclone build script

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,10 +26,11 @@ jobs:
       with:
         go-version: 1.20
       id: go
-    - name: Force NDK version
-      run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;25.0.8775105"
-    - name: Build rclone
-      run: ./gradlew rclone:buildAll
+    - name: Install NDK
+      run: |
+        NDK_VERSION="$(grep -E "^de\.felixnuesse\.extract\.ndkVersion=" gradle.properties | cut -d'=' -f2)"
+        yes | sudo "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses
+        sudo "${ANDROID_HOME}/tools/bin/sdkmanager" "ndk;${NDK_VERSION}"
     - name: Build app
       run: ./gradlew assembleOssDebug
     - name: Upload APK (arm)

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ freeline_project_description.json
 # Don't version native libraries or IDE artifacts. Module config should be done in gradle.
 # Generated artifacts (apks, libraries) just slow down cloning and can be recreated from source
 # anyways.
-app/lib/
 release/
 
 .idea/encodings.xml

--- a/README.md
+++ b/README.md
@@ -72,21 +72,23 @@ Usage
 
 Developing
 ------------
-[See the developer-documentation](https://x0b.github.io/dev/).
 
-Build rclone manually run:
+You should first make sure you have:
 
+- Go 1.20+ installed and in your PATH
+- Java installed and in your PATH
+- Android SDK command-line tools installed OR the NDK version specified in `gradle.properties`
+  installed
+
+You can then build the app normally from Android Studio or from CLI by running:
+
+```sh
+# Debug build
+./gradlew assembleOssDebug
+
+# or release build
+./gradlew assembleOssRelease
 ```
-./gradlew rclone:buildAll
-```
-
-When building rclone with a go version that is too old (eg 1.15.5), this error may show up:
-
-```
-ld.lld: error: duplicate symbol: x_cgo_inittls
-```
-
-It can be fixed by using a more recent version of go.
 
 Known Issues
 ------------
@@ -96,20 +98,6 @@ Known Issues
 Contributing
 ------------
 See [CONTRIBUTING](./CONTRIBUTING.md)
-
-
-Building
-------------
-```
-// choose the appropriate version for your device
-cd rclone
-../gradlew rclone:buildNative // For all devices
-../gradlew rclone:buildArm64
-../gradlew rclone:buildArm
-../gradlew rclone:buildx86
-../gradlew rclone:buildx64
-```
-
 
 
 License

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+/lib

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         }
     }
     compileSdkVersion 33
-    ndkVersion '25.0.8775105'
+    ndkVersion project.properties['de.felixnuesse.extract.ndkVersion']
     defaultConfig {
         applicationId 'de.felixnuesse.extract'
         minSdkVersion 23
@@ -67,10 +67,11 @@ android {
     }
 
     project.ext.versionCodes = [
-            'armeabi-v7a': 6,
-            'arm64-v8a'  : 7,
-            'x86'        : 8,
-            'x86_64'     : 9]
+        'armeabi-v7a': 6,
+        'arm64-v8a'  : 7,
+        'x86'        : 8,
+        'x86_64'     : 9
+    ]
 
     android.applicationVariants.all { variant ->
         variant.outputs.each { output ->

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,13 @@ import java.text.SimpleDateFormat
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
+tasks.whenTaskAdded { task ->
+    // Build rclone beforehand.
+    if (task.name.startsWith('compile')) {
+        task.dependsOn(':rclone:buildAll')
+    }
+}
+
 android {
     signingConfigs {
         github_x0b {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-
     ext.kotlinVersion = '1.7.20'
     repositories {
         google()

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.enableJetifier=false
 android.useAndroidX=true
+de.felixnuesse.extract.rCloneVersion=1.61.1
+de.felixnuesse.extract.ndkVersion=25.0.8775105
+de.felixnuesse.extract.ndkToolchainVersion=33

--- a/rclone/.gitignore
+++ b/rclone/.gitignore
@@ -1,1 +1,1 @@
-/gopath
+/cache

--- a/rclone/build.gradle
+++ b/rclone/build.gradle
@@ -9,7 +9,8 @@
 //
 // Supported host systems:
 //  - linux x64
-//  - mac os x64
+//  - macOS x64
+//  - macOS arm64 (Silicon)
 //  - windows x64
 //
 // Prerequisites:
@@ -90,12 +91,15 @@ def getCrossCompiler(abi) {
     def osName = System.properties['os.name']
     def osArch = System.properties['os.arch']
     def os = null
-    if (osName.contains('windows') && osArch == 'amd64') {
-        os = "windows-x86_64"
-    } else if (osName.contains("linux")) {
-        os = "linux-x86_64"
-    } else if (osName.contains('mac')) {
-        os = "darwin-x86_64"
+    if (osName.startsWith('Windows') && osArch == 'amd64') {
+        os = 'windows-x86_64'
+    } else if (osName.startsWith('Linux') && osArch == 'amd64') {
+        os = 'linux-x86_64'
+    } else if (osName.startsWith('Mac') && ['aarch64', 'amd64'].contains(osArch)) {
+        // Note that despite what the name suggests, the clang binary shipped
+        // with the NDK is a universal object file which should work on both
+        // x86_64 and arm64 (Silicon-based) architectures.
+        os = 'darwin-x86_64'
     }
     if (os == null) {
         throw new GradleException('Unsupported host OS or architecture.')

--- a/rclone/build.gradle
+++ b/rclone/build.gradle
@@ -11,191 +11,203 @@
 //  - linux x64
 //  - mac os x64
 //  - windows x64
-//  - windows x86 (with NDK 21b installed)
 //
-// Prerequisits:
-//  - go 1.18
-//  - ndk
+// Prerequisites:
+//  - go 1.20+
+//  - Either Android SDK command-line tools, or the expected NDK version (see gradle.properties).
 
-// Rclone version - any git reference (tag, branch, hash) should work
-def buildTag = 'v1.61.1'
-ext.ndkVersion = '25.0.8775105'
-
-//
-// DO NOT EDIT ANYTHING BELOW
-//
-
-import java.nio.file.Files
 import java.nio.file.Paths
 
-def configureNdk() {
-    def osName = System.properties['os.name'].toLowerCase()
-    def osArch = System.properties['os.arch']
+ext {
+    NDK_VERSION = project.properties['de.felixnuesse.extract.ndkVersion']
+    NDK_TOOLCHAIN_VERSION = project.properties['de.felixnuesse.extract.ndkToolchainVersion']
+    RCLONE_VERSION = project.properties['de.felixnuesse.extract.rCloneVersion']
+    RCLONE_MODULE = 'github.com/rclone/rclone'
+    RCLONE_CUSTOM_VERSION_SUFFIX = '-extract'
 
-    def os = ''
-    if (osName.contains('windows')) {
-        if(osArch.equals('amd64')) {
-            os = "windows-x86_64"
-        } else if (osArch.equals('x86')) {
-            // NDK has dropped x86 windows support in NDK 21 and greater. This
-            // may break at for any reason when the golang tolchain is
-            // upgraded.
-            os = "windows"
-            ext.ndkVersion = '20.1.5948944'
+    PROJECT_DIR = projectDir.absolutePath
+    CACHE_PATH = Paths.get(PROJECT_DIR, 'cache').toString()
+    GOPATH = Paths.get(CACHE_PATH, 'gopath').toString()
+    OUTPUT_BASE_PATH = Paths.get(PROJECT_DIR, '..', 'app', 'lib').toAbsolutePath().toString()
+}
+
+def findSdkDir() {
+    def androidHome = System.getenv('ANDROID_HOME')
+    if (androidHome != null) {
+        return androidHome
+    }
+
+    def localPropertiesFile = project.rootProject.file('local.properties')
+    if (localPropertiesFile.exists()) {
+        Properties properties = new Properties()
+        properties.load(localPropertiesFile.newDataInputStream())
+        def sdkDir = properties.get('sdk.dir')
+        if (sdkDir != null) {
+            return sdkDir
         }
+    }
+
+    throw new GradleException(
+        "Couldn't locate your android SDK. Make sure you set sdk.dir property"
+        + " in your local.properties at the root of the project or set"
+        + " ANDROID_HOME environment variable."
+    )
+}
+
+def findNdkDir() {
+    def sdkDir = findSdkDir()
+    def ndkPath = Paths.get(sdkDir, 'ndk', NDK_VERSION).toAbsolutePath()
+    if (!ndkPath.toFile().exists()) {
+        // NDK not found. Let's try to install it.
+        def sdkManagerPath = Paths.get(
+            sdkDir,
+            'cmdline-tools',
+            'latest',
+            'bin',
+            'sdkmanager'
+        ).toString()
+        if (System.properties['os.name'].startsWith('Windows')) {
+            sdkManagerPath += '.bat'
+        }
+        try {
+            exec {
+                commandLine sdkManagerPath, "--install", "ndk;${NDK_VERSION}"
+            }
+        } catch (exc) {
+            logger.error(exc.toString())
+            // NDK installation failed. Just raise an error.
+            throw new GradleException(
+                "Couldn't find a ndk bundle in ${ndkPath.toString()}. Make sure that you have the"
+                + " proper version installed in Android Studio's SDK Manager or run"
+                + " \"${sdkManagerPath} --install 'ndk;${NDK_VERSION}'\"."
+            )
+        }
+    }
+    return ndkPath.toString()
+}
+
+def getCrossCompiler(abi) {
+    def osName = System.properties['os.name']
+    def osArch = System.properties['os.arch']
+    def os = null
+    if (osName.contains('windows') && osArch == 'amd64') {
+        os = "windows-x86_64"
     } else if (osName.contains("linux")) {
         os = "linux-x86_64"
     } else if (osName.contains('mac')) {
         os = "darwin-x86_64"
-    } else {
-        throw new GradleException("OS=${osName}/ARCH=${osArch} not supported")
+    }
+    if (os == null) {
+        throw new GradleException('Unsupported host OS or architecture.')
     }
 
+    def abiToCompiler = [
+        'armeabi-v7a': "armv7a-linux-androideabi${NDK_TOOLCHAIN_VERSION}-clang",
+        'arm64-v8a': "aarch64-linux-android${NDK_TOOLCHAIN_VERSION}-clang",
+        'x86': "i686-linux-android${NDK_TOOLCHAIN_VERSION}-clang",
+        'x86_64': "x86_64-linux-android${NDK_TOOLCHAIN_VERSION}-clang",
+    ]
 
-    // locate NDK
-    def androidHome = System.getenv('HOME')+"/Android/Sdk/"
-    def ndkBasePath
-    if (androidHome != null) {
-        def canonicalPath = Paths.get(androidHome, 'ndk', ext.ndkVersion)
-        def bundlePath = Paths.get(androidHome, 'ndk-bundle')
-        if (Files.exists(canonicalPath) && checkNdk(canonicalPath)) {
-            ndkBasePath = canonicalPath;
-        } else if (Files.exists(bundlePath) && checkNdk(bundlePath)) {
-            ndkBasePath = bundlePath;
-        }
-    } else if (androidNdkHome != null && checkNdk(androidNdkHome)) {
-        ndkBasePath = Paths.get(androidNdkHome)
-    }
-    // check NDK
-
-    if (ndkBasePath == null) {
-        throw GradleException("NDK ${ext.ndkVersion} not found")
-    }
-
-    return ndkBasePath.resolve(Paths.get('toolchains', 'llvm', 'prebuilt', os, 'bin'))
+    return Paths.get(
+        findNdkDir(),
+        'toolchains',
+        'llvm',
+        'prebuilt',
+        os,
+        'bin',
+        abiToCompiler[abi],
+    )
 }
 
-def checkNdk(ndkBasePath) {
-    def propertiesPath = ndkBasePath.resolve('source.properties')
-    def ndkProperties = new Properties()
-    ndkProperties.load(file(propertiesPath).newReader())
-    return ndkProperties['Pkg.Revision'] == ext.ndkVersion
+def getOutputPath(abi) {
+    return Paths.get(OUTPUT_BASE_PATH, abi, 'librclone.so').toString()
 }
 
-def configureGo() {
-    def localGo = Paths.get('golang/go/bin/go')
-    return Files.exists(localGo) ? localGo : 'go'
-}
+def buildRclone(abi) {
+    def abiToEnv = [
+        'armeabi-v7a': ['GOARCH': 'arm', 'GOARM': '7'],
+        'arm64-v8a': ['GOARCH': 'arm64'],
+        'x86': ['GOARCH': '386'],
+        'x86_64': ['GOARCH': 'amd64'],
+    ]
 
-def repository = 'github.com/rclone/rclone'
-def repositoryRef = repository + '@' + buildTag
-def ldflags = "-X github.com/rclone/rclone/fs.Version=${buildTag}-rcx"
-def goPath = Paths.get(projectDir.absolutePath, 'gopath').toAbsolutePath().toString()
-def appLibPath = Paths.get(projectDir.absolutePath, '../app/lib').toAbsolutePath().toString()
-def ndkPrefix = configureNdk()
-def goBinary = configureGo()
-
-
-task fetchRclone(type: Exec) {
-    mkdir "gopath"
-    environment 'GOPATH', goPath
-    environment "GO111MODULE", "on"
-    commandLine 'go', 'install', repositoryRef
-
-    ignoreExitValue true
-    errorOutput = new ByteArrayOutputStream()
-    doLast {
-        if (execResult.getExitValue() != 0) {
-            throw new GradleException("Error running go get: \n${errorOutput.toString()}")
-        }
-    }
-}
-
-task cleanNative {
-    enabled = false
-    doLast {
-        delete "${appLibPath}/armeabi-v7a/librclone.so"
-        delete "${appLibPath}/arm64-v8a/librclone.so"
-        delete "${appLibPath}/x86/librclone.so"
-        delete "${appLibPath}/x86_64/librclone.so"
-    }
-}
-
-task buildArm(type: Exec) {
-    dependsOn fetchRclone
-    environment 'GOPATH', goPath
-    def crossCompiler = ndkPrefix.resolve('armv7a-linux-androideabi21-clang')
-    environment 'CC', crossCompiler
-    environment 'CC_FOR_TARGET', crossCompiler
-    environment 'GOOS', 'android'
-    environment 'GOARCH', 'arm'
-    environment 'GOARM', '7'
-    environment 'CGO_ENABLED', '1'
-    environment 'CGO_LDFLAGS', "-fuse-ld=lld -s"
-    workingDir Paths.get(goPath, "pkg/mod/${repositoryRef}".split('/'))
-    def artifactTarget = "${appLibPath}/armeabi-v7a/librclone.so"
-    commandLine 'go', 'build', '-v', '-tags', 'android noselfupdate', '-trimpath', '-ldflags', ldflags, '-o', artifactTarget, '.'
-
-    ignoreExitValue true
-    errorOutput = new ByteArrayOutputStream()
-    doLast {
-        if (execResult.getExitValue() != 0) {
-            throw new GradleException("Error running go build: \n${errorOutput.toString()}")
+    return {
+        doLast {
+            exec {
+                environment 'GOPATH', GOPATH
+                def crossCompiler = getCrossCompiler(abi)
+                environment 'CC', crossCompiler
+                environment 'CC_FOR_TARGET', crossCompiler
+                environment 'GOOS', 'android'
+                environment 'CGO_ENABLED', '1'
+                environment 'CGO_LDFLAGS', '-fuse-ld=lld -s'
+                abiToEnv[abi].each {entry -> environment entry.key, entry.value}
+                workingDir CACHE_PATH
+                def ldflags = "-X github.com/rclone/rclone/fs.Version=${RCLONE_VERSION}${RCLONE_CUSTOM_VERSION_SUFFIX}"
+                commandLine (
+                    'go',
+                    'build',
+                    '-tags',
+                    'android noselfupdate',
+                    '-trimpath',
+                    '-ldflags',
+                    ldflags,
+                    '-o',
+                    getOutputPath(abi),
+                    RCLONE_MODULE
+                )
+            }
         }
     }
 }
 
-task buildArm64(type: Exec) {
-    dependsOn fetchRclone
-    environment 'GOPATH', goPath
-    def crossCompiler = ndkPrefix.resolve('aarch64-linux-android21-clang')
-    environment 'CC', crossCompiler
-    environment 'CC_FOR_TARGET', crossCompiler
-    environment 'GOOS', 'android'
-    environment 'GOARCH', 'arm64'
-    environment 'CGO_ENABLED', '1'
-    environment 'CGO_LDFLAGS', "-fuse-ld=lld -s"
-    workingDir Paths.get(goPath, "pkg/mod/${repositoryRef}".split('/'))
-    def artifactTarget = "${appLibPath}/arm64-v8a/librclone.so"
-    commandLine 'go', 'build', '-v', '-tags', 'android noselfupdate', '-trimpath', '-ldflags', ldflags, '-o', artifactTarget, '.'}
-
-task buildx86(type: Exec) {
-    dependsOn fetchRclone
-    environment 'GOPATH', goPath
-    def crossCompiler = ndkPrefix.resolve('i686-linux-android21-clang')
-    environment 'CC', crossCompiler
-    environment 'CC_FOR_TARGET', crossCompiler
-    environment 'GOOS', 'android'
-    environment 'GOARCH', '386'
-    environment 'CGO_ENABLED', '1'
-    environment 'CGO_LDFLAGS', "-fuse-ld=lld -s"
-    workingDir Paths.get(goPath, "pkg/mod/${repositoryRef}".split('/'))
-    def artifactTarget = "${appLibPath}/x86/librclone.so"
-    commandLine 'go', 'build', '-v', '-tags', 'android noselfupdate', '-trimpath', '-ldflags', ldflags, '-o', artifactTarget, '.'
+task createRcloneModule(type: Exec) {
+    // We create a dummy go module to be able to checkout our specific rclone
+    // version later on.
+    onlyIf { !Paths.get(CACHE_PATH, 'go.mod').toFile().exists() }
+    Paths.get(CACHE_PATH).toFile().mkdirs()
+    workingDir CACHE_PATH
+    environment 'GOPATH', GOPATH
+    commandLine 'go', 'mod', 'init', 'rclone'
 }
 
-task buildx64(type: Exec) {
-    dependsOn fetchRclone
-    environment 'GOPATH', goPath
-    def crossCompiler = ndkPrefix.resolve('x86_64-linux-android21-clang')
-    environment 'CC', crossCompiler
-    environment 'CC_FOR_TARGET', crossCompiler
-    environment 'GOOS', 'android'
-    environment 'GOARCH', 'amd64'
-    environment 'CGO_ENABLED', '1'
-    environment 'CGO_LDFLAGS', "-fuse-ld=lld -s"
-    workingDir Paths.get(goPath, "pkg/mod/${repositoryRef}".split('/'))
-    def artifactTarget = "${appLibPath}/x86_64/librclone.so"
-    commandLine 'go', 'build', '-v', '-tags', 'android noselfupdate', '-trimpath', '-ldflags', ldflags, '-o', artifactTarget, '.'
+task checkoutRclone(type: Exec, dependsOn: createRcloneModule) {
+    workingDir CACHE_PATH
+    environment 'GOPATH', GOPATH
+    commandLine 'go', 'get', '-v', '-d', "${RCLONE_MODULE}@v${RCLONE_VERSION}"
+}
+
+task buildArm(dependsOn: checkoutRclone) {
+    configure buildRclone('armeabi-v7a')
+}
+
+task buildArm64(dependsOn: checkoutRclone) {
+    configure buildRclone('arm64-v8a')
+}
+
+task buildx86(dependsOn: checkoutRclone) {
+    configure buildRclone('x86')
+}
+
+task buildx64(dependsOn: checkoutRclone) {
+    configure buildRclone('x86_64')
 }
 
 task buildAll {
-    dependsOn fetchRclone
-    dependsOn buildArm
-    dependsOn buildArm64
-    dependsOn buildx86
-    dependsOn buildx64
+    dependsOn buildArm, buildArm64, buildx86, buildx64
 }
 
-buildAll.mustRunAfter(buildArm, buildArm64, buildx86, buildx64)
+task clean {
+    doLast {
+        exec {
+            environment 'GOPATH', GOPATH
+            commandLine 'go', 'clean', '-cache', '-testcache', '-modcache', '-fuzzcache'
+        }
+        delete CACHE_PATH
+        delete fileTree(OUTPUT_BASE_PATH).matching {
+            include '**/librclone.so'
+        }
+    }
+}
+
 defaultTasks 'buildAll'


### PR DESCRIPTION
I revived this old contribution I had made to RCx which has never been merged (probably because it also included many other changes, which was a clumsy move from me). I hope you'll like it, as it introduces the following improvements to the rclone build script:

- Take `ANDROID_HOME` environment into account (fixes #66)
- Automatically install expected NDK version when possible, otherwise
  provide a relevant error message
- Configure rclone, NDK, and toolchain versions in gradle.properties
  rather than hidden somewhere in the build.gradle file
- Refactor code into separate functions and tasks so as to limit code
  duplication and make the build script be more manageable
- Drop support for Windows x86 as host system (I don't believe it's still
  widely used, and it required falling back to an old NDK which is gross)
- Automatically build rclone when building the main app, to avoid the
  confusing and error-prone rclone pre-build step.
- Explicit Mac Silicon support.

I also tested building on Windows with Android Studio and it worked, so maybe it also fixes #64, but I can't guarantee. All I can say is that I needed to add Go and the JDK into PATH, and that SDK command-line tools OR the expected NDK version must still be installed manually (which is not much different from Linux).

I'm pretty sure that in my initial contribution, Android Studio would provide a prompt suggesting to install the NDK version specified in the `ndkVersion`  field, but it seems that it is no longer the case. I haven't found a way to set that back up, but in the meantime, the error message should be very explicit and if SDK command-line tools are installed, the NDK may be automatically installed anyways. So this is not worse compared to the current situation anyways.