### PR TITLE
fix the app not respecting the notification setting

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/notifications/SyncServiceNotifications.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/notifications/SyncServiceNotifications.kt
@@ -73,7 +73,7 @@ class SyncServiceNotifications(var mContext: Context) {
             .setPriority(NotificationCompat.PRIORITY_LOW)
         val notificationManager = NotificationManagerCompat.from(mContext)
         notificationManager.notify(notificationId, builder.build())
-        createSummaryNotificationForSuccess()
+        //createSummaryNotificationForSuccess()
     }
 
     // this will show up if mul


### PR DESCRIPTION
The easiest way to fix the https://github.com/newhinton/extRact/issues/81 issue. I checked the code and this function is only mentioned in this line, so commenting it out shouldn't break anything. For now, the notifications seem to be a bit disorganized, so it's a thing to rethink in the future. But for now it's the best I can do, since I can't test the app in Android Studio for some reason, so I can't try to rebuild it on my own without testing. But I'm sure it's a solution for the case mentioned in the linked issue: A user wants to disable notifications about successful syncs, and may be able to disable them in the app settings (Sync service success). It works, but then the app seems to call the commented func, which shows a different line.

To test it properly:
1. Add a task and start it manually - you'll see a success notification after it's finished
2. Disable 'Sync service success' notifications in the app settings
3. Run the sync task again. It should not show '%s was successful' as we don't want to get spammed if there are no problems

My commit only affects the success summary notifications. It looks like the previous maintainer wanted to handle this differently, but the function is not called from any other file.

Please test it, merge it, and release a beta asap, because we need it to work this way so badly, hahah :D