### PR TITLE
Added move functionality to Tasks

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
@@ -238,7 +238,15 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
         taskToPopulate.title = findViewById<EditText>(R.id.task_title_textfield).text.toString()
         val remotename = remoteDropdown.selectedItem.toString()
         taskToPopulate.remoteId = remotename
-        val direction = syncDirection.selectedItemPosition + 1
+        // Map spinner position to internal SyncDirection constants explicitly
+        val directionMap = arrayOf(
+            SyncDirectionObject.SYNC_LOCAL_TO_REMOTE,
+            SyncDirectionObject.SYNC_REMOTE_TO_LOCAL,
+            SyncDirectionObject.COPY_LOCAL_TO_REMOTE,
+            SyncDirectionObject.COPY_REMOTE_TO_LOCAL,
+            SyncDirectionObject.MOVE_LOCAL_TO_REMOTE
+        )
+        val direction = if (syncDirection.selectedItemPosition >= 0 && syncDirection.selectedItemPosition < directionMap.size) directionMap[syncDirection.selectedItemPosition] else SyncDirectionObject.SYNC_LOCAL_TO_REMOTE
         for (ri in rcloneInstance.remotes) {
             if (ri.name == taskToPopulate.remoteId) {
                 taskToPopulate.remoteType = ri.type
@@ -246,7 +254,7 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
         }
         taskToPopulate.remotePath = remotePath.text.toString()
         taskToPopulate.localPath = localPath.text.toString()
-        taskToPopulate.direction = direction
+    taskToPopulate.direction = direction
 
         taskToPopulate.wifionly = switchWifi.isChecked
         taskToPopulate.md5sum = switchMD5sum.isChecked
@@ -491,7 +499,17 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
 
             override fun onNothingSelected(adapterView: AdapterView<*>?) {}
         }
-        syncDirection.setSelection((((existingTask?.direction?.minus(1)) ?: 0)) )
+        // Ensure spinner selection reflects existing task direction by mapping stored constant to index
+        val directionMap = arrayOf(
+            SyncDirectionObject.SYNC_LOCAL_TO_REMOTE,
+            SyncDirectionObject.SYNC_REMOTE_TO_LOCAL,
+            SyncDirectionObject.COPY_LOCAL_TO_REMOTE,
+            SyncDirectionObject.COPY_REMOTE_TO_LOCAL,
+            SyncDirectionObject.MOVE_LOCAL_TO_REMOTE
+        )
+        val currentDirection = existingTask?.direction ?: SyncDirectionObject.SYNC_LOCAL_TO_REMOTE
+        val selectionIndex = directionMap.indexOf(currentDirection).let { if (it >= 0) it else 0 }
+        syncDirection.setSelection(selectionIndex)
     }
 
     private fun updateSpinnerDescription(value: Int) {
@@ -503,6 +521,8 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
                 getString(R.string.description_sync_direction_sync_tolocal)
             SyncDirectionObject.COPY_LOCAL_TO_REMOTE -> text =
                 getString(R.string.description_sync_direction_copy_toremote)
+            SyncDirectionObject.MOVE_LOCAL_TO_REMOTE -> text =
+                getString(R.string.description_sync_direction_move_toremote)
             SyncDirectionObject.COPY_REMOTE_TO_LOCAL -> text =
                 getString(R.string.description_sync_direction_copy_tolocal)
             SyncDirectionObject.SYNC_BIDIRECTIONAL -> text =

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Items/SyncDirectionObject.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Items/SyncDirectionObject.java
@@ -36,6 +36,9 @@ public class SyncDirectionObject {
     public static final int SYNC_BIDIRECTIONAL_INITIAL = 5;
     public static final int SYNC_BIDIRECTIONAL = 6;
 
+    // Move local to remote (use rclone move)
+    public static final int MOVE_LOCAL_TO_REMOTE = 7;
+
 
     public static String[] getOptionsArray(Context context) {
         return context.getResources().getStringArray(R.array.sync_direction_array);

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -707,6 +707,10 @@ public class Rclone {
             Collections.addAll(directionParameter, "copy", localPath, remoteSection);
             directionParameter.addAll(defaultParameter);
             command = createCommandWithOptions(directionParameter);
+        } else if (syncDirection == SyncDirectionObject.MOVE_LOCAL_TO_REMOTE) {
+            Collections.addAll(directionParameter, "move", localPath, remoteSection);
+            directionParameter.addAll(defaultParameter);
+            command = createCommandWithOptions(directionParameter);
         }else if (syncDirection == SyncDirectionObject.COPY_REMOTE_TO_LOCAL) {
             Collections.addAll(directionParameter, "copy", remoteSection, localPath);
             directionParameter.addAll(defaultParameter);

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/TasksRecyclerViewAdapter.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/TasksRecyclerViewAdapter.java
@@ -105,6 +105,9 @@ public class TasksRecyclerViewAdapter extends RecyclerView.Adapter<TasksRecycler
             case SyncDirectionObject.COPY_REMOTE_TO_LOCAL:
                 holder.taskSyncDirection.setText(view.getResources().getString(R.string.copy));
                 break;
+            case SyncDirectionObject.MOVE_LOCAL_TO_REMOTE:
+                holder.taskSyncDirection.setText(view.getResources().getString(R.string.move));
+                break;
             case SyncDirectionObject.SYNC_BIDIRECTIONAL_INITIAL:
             case SyncDirectionObject.SYNC_BIDIRECTIONAL:
                 holder.taskSyncDirection.setText(view.getResources().getString(R.string.bisync));

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -296,6 +296,7 @@
     <string name="task_copied_id_to_clipboard">Aufgabenkennung "%s" in Zwischenspeicher kopiert!</string>
     <string name="importer_unknown_error">Unbekannter Fehler beim Importieren!</string>
     <string name="sync_direction_copy_local_remote">Kopiere von lokalem Speicher zu entferntem Speicher</string>
+    <string name="sync_direction_move_local_remote">Verschiebe von lokalem Speicher zu entferntem Speicher</string>
     <string name="sync_direction_copy_remote_local">Kopiere von entferntem Speicher nach lokalem Speicher</string>
     <string name="copy">Kopieren</string>
     <string name="operation_success">%s war erfolgreich</string>
@@ -435,6 +436,7 @@
     <string name="description_sync_direction_sync_toremote">Synchronisieren Sie Dateien vom lokalen Speicher auf den entfernten Speicher. Alle Dateien, die lokal nicht vorhanden sind, werden auf dem entfernten Speicher gelöscht. Dies betrifft nur die Dateien auf dem entfernten Speicher.</string>
     <string name="description_sync_direction_copy_toremote">Kopiere neue oder geänderte Dateien vom lokalen Speicher zum entfernten Speicher. Dateien werden nicht gelöscht, bestehende Dateien auf dem entfernten Speicher können überschrieben werden.</string>
     <string name="description_sync_direction_copy_tolocal">Kopiere neue oder geänderte Dateien vom entfernten Speicher zum lokalen Speicher. Dateien werden nicht gelöscht, bestehende Dateien auf dem lokalen Speicher können überschrieben werden.</string>
+    <string name="description_sync_direction_move_toremote">Verschiebe Dateien vom lokalen Speicher zum entfernten Speicher. Dateien werden nach erfolgreichem Transfer vom lokalen Speicher entfernt.</string>
     <string name="description_sync_direction_sync_bidirectional">Stellt sicher das lokaler und entfernter Speicher identisch sind. Dateien werden gelöscht, geupdated und erstellt nach Bedarf.</string>
     <string name="intro_success">Erfolg!</string>
     <string name="dynamic_config_unknown_error">Der Anbieter ist unbekannt!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,6 @@
     <string name="select_all">Select all</string>
     <string name="serve">Serve…</string>
     <string name="download">Download</string>
-    <string name="move">Move</string>
     <string name="rename">Rename</string>
     <string name="delete">Delete</string>
     <string name="app_version">App Version</string>
@@ -333,6 +332,8 @@
     <string name="task_copied_id_to_clipboard">Copied ID "%s" to clipboard!</string>
     <string name="importer_unknown_error">Unknown error importing task!</string>
     <string name="sync_direction_copy_local_remote">Copy local to remote</string>
+    <string name="sync_direction_move_local_remote">Move local to remote</string>
+    <string name="move">Move</string>
     <string name="sync_direction_copy_remote_local">Copy remote to local</string>
     <string name="copy">Copy</string>
     <string name="operation_success">%s sync successful</string>
@@ -486,6 +487,7 @@
     <string name="description_sync_direction_copy_toremote">Copy new or modified files from local storage to remote storage. No files are deleted, existing files on the remote may be overwritten.</string>
     <string name="description_sync_direction_copy_tolocal">Copy new or modified files from remote storage to local storage. No files are deleted, existing files on the local storage may be overwritten.</string>
     <string name="description_sync_direction_sync_bidirectional">Make sure local and remote storage have the same files by transferring, downloading, and deleting files as needed to maintain an identical folder structure.</string>
+    <string name="description_sync_direction_move_toremote">Move files from local storage to remote storage. Files will be removed from the local source after successful transfer.</string>
     <string name="filter_type_include">Include</string>
     <string name="filter_type_exclude">Exclude</string>
     <string name="intro_success">Success!</string>

--- a/app/src/main/res/values/sync_direction_array.xml
+++ b/app/src/main/res/values/sync_direction_array.xml
@@ -5,6 +5,7 @@
         <item>@string/sync_direction_remote_local</item>
         <item>@string/sync_direction_copy_local_remote</item>
         <item>@string/sync_direction_copy_remote_local</item>
+        <item>@string/sync_direction_move_local_remote</item>
         <!--<item>@string/sync_direction_bidirectional</item>-->
     </string-array>
 </resources>


### PR DESCRIPTION
# UseCase:
A feature is needed that moves files from a folder on the android device (local) to the remote repository. This is different from copy commands which are implemente by Round-Sync tasks. The difference is that files which are moved and not copied are deleted from the local device after the process.
# Implementation
Rclone provides the ```rclone move``` [command](https://rclone.org/commands/rclone_move/) this is wrapped according to given software architecture by this pull request. Namely tasks for moving files from given folders can be added by dropdown in the task creation menu.