### PR TITLE
Allow manual editing of the path when configuring a task

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
@@ -61,6 +61,8 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
     private lateinit var onSuccessDropdown: Spinner
 
 
+    private lateinit var localPathPickerButton: ImageButton
+    private lateinit var remotePathPickerButton: ImageButton
     private lateinit var filterOptionsButton: ImageButton
 
 
@@ -162,6 +164,8 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
             }
         }
 
+        localPathPickerButton = findViewById(R.id.task_local_path_picker_button)
+        remotePathPickerButton = findViewById(R.id.task_remote_path_picker_button)
         filterOptionsButton = findViewById(R.id.task_edit_filter_options_button)
         filterOptionsButton.setOnClickListener {
             val filter = if(filterDropdown.selectedItemPosition > 0 && filterDropdown.selectedItemPosition < filterDropdown.count) filterItems[filterDropdown.selectedItemPosition - 1] else null
@@ -306,14 +310,11 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
         existingTask.let {
             localPath.setText(it?.localPath ?: "")
         }
-        localPath.onFocusChangeListener =
-            View.OnFocusChangeListener { v: View?, hasFocus: Boolean ->
-                if (hasFocus) {
-                    val intent = Intent(this.applicationContext, FilePicker::class.java)
-                    intent.putExtra(FilePicker.FILE_PICKER_PICK_DESTINATION_TYPE, true)
-                    startActivityForResult(intent, REQUEST_CODE_FP_LOCAL)
-                }
-            }
+        localPathPickerButton.setOnClickListener {
+            val intent = Intent(this.applicationContext, FilePicker::class.java)
+            intent.putExtra(FilePicker.FILE_PICKER_PICK_DESTINATION_TYPE, true)
+            startActivityForResult(intent, REQUEST_CODE_FP_LOCAL)
+        }
     }
 
     private fun prepareRemote() {
@@ -342,15 +343,10 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
             override fun onNothingSelected(parentView: AdapterView<*>?) {}
         }
 
-        // Todo: This will break if the remote changed, but the path did not.
-        //       Catch this issue by forcing the path to be emtpy
-        remotePath.onFocusChangeListener = object : View.OnFocusChangeListener {
-            override fun onFocusChange(p0: View?, p1: Boolean) {
-                startRemotePicker(
-                    rcloneInstance.getRemoteItemFromName(remoteDropdown.selectedItem.toString()), "/"
-                )
-                remotePath.clearFocus()
-            }
+        remotePathPickerButton.setOnClickListener {
+            startRemotePicker(
+                rcloneInstance.getRemoteItemFromName(remoteDropdown.selectedItem.toString()), "/"
+            )
         }
     }
 

--- a/app/src/main/res/layout/content_task.xml
+++ b/app/src/main/res/layout/content_task.xml
@@ -150,15 +150,32 @@
                         android:textAppearance="@style/TextAppearance.AppCompat.Display1"
                         android:textSize="24sp" />
 
-                    <EditText
-                        android:id="@+id/task_local_path_textfield"
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_margin="8dp"
-                        android:autofillHints=""
-                        android:hint="@string/task_edit_hint_local"
-                        android:inputType=""
-                        android:minHeight="48dp" />
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal">
+
+                        <ImageButton
+                            android:id="@+id/task_local_path_picker_button"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
+                            android:background="?selectableItemBackgroundBorderless"
+                            android:contentDescription="@string/task_edit_hint_local"
+                            android:src="@drawable/ic_folder_open" />
+
+                        <EditText
+                            android:id="@+id/task_local_path_textfield"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:autofillHints=""
+                            android:hint="@string/task_edit_hint_local"
+                            android:inputType="text"
+                            android:minHeight="48dp" />
+
+                    </LinearLayout>
 
                 </LinearLayout>
             </androidx.cardview.widget.CardView>
@@ -193,15 +210,32 @@
                         android:contentDescription="@string/description_sync_direction"
                         android:minHeight="48dp" />
 
-                    <EditText
-                        android:id="@+id/task_remote_path_textfield"
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_margin="8dp"
-                        android:autofillHints=""
-                        android:hint="@string/task_edit_hint_remote"
-                        android:inputType=""
-                        android:minHeight="48dp" />
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal">
+
+                        <ImageButton
+                            android:id="@+id/task_remote_path_picker_button"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
+                            android:background="?selectableItemBackgroundBorderless"
+                            android:contentDescription="@string/task_edit_hint_remote"
+                            android:src="@drawable/ic_folder_open" />
+
+                        <EditText
+                            android:id="@+id/task_remote_path_textfield"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:autofillHints=""
+                            android:hint="@string/task_edit_hint_remote"
+                            android:inputType="text"
+                            android:minHeight="48dp" />
+
+                    </LinearLayout>
                 </LinearLayout>
             </androidx.cardview.widget.CardView>
 


### PR DESCRIPTION
Some targets (ex: Hetzner) will not work if the path configured starts with a `/`, which is what Round Sync currently sets after selecting the folder. It's impossible to manually edit the path after the selection, and the only way to get it working is by editing the configuration files manually and then importing them.

With this change, we still have the interactive directory selector but allows manual editing of the directory afterwards.

New behavior:

https://github.com/user-attachments/assets/dc08855b-930e-4ba8-ada9-03416dbc0e1a

